### PR TITLE
Travis-CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+sudo: false
+
+# Lightweight VM, because we install all the tools on our own.
+language: c
+
+cache:
+  directories:
+  - $HOME/.stack
+
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+before_install:
+  # Download and unpack the stack executable
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:$PATH
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - stack config set system-ghc --global true
+
+install:
+  - travis_wait stack --no-terminal --install-ghc setup
+
+script:
+  - stack test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Parser for the Nevada Revised Statutes 
 ======================================
 
+[![Build Status](https://travis-ci.org/public-law/nevada-revised-statutes-parser.svg?branch=master)](https://travis-ci.org/public-law/nevada-revised-statutes-parser)
+
 **Input:** The Nevada laws (i.e., the Nevada Revised Statutes) [website](https://www.leg.state.nv.us/NRS/).
 
 **Output:** Semantic JSON:


### PR DESCRIPTION
As Travis's Haskell stack is using cabal, and this repository requires the Haskell Tool Stack, there was a need for some [custom configuration](https://docs.haskellstack.org/en/stable/travis_ci/).
First run will take some time, as there are bunch of dependencies, but sequential runs should run faster. 

This resolves #17.